### PR TITLE
add Config context, add Button, InputBox Component

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,18 +1,15 @@
 import React from 'react';
 import styled from 'styled-components';
-import { ChatContainer } from 'components';
-import { MessageList } from 'shared/models';
+import { ChatContainer, InputBox } from 'components';
+import { Config, MessageList } from 'shared/models';
+import { configContext } from 'context';
 
-interface StyleProps {
-  width?: number;
-  height?: number;
-}
-
-interface Props extends StyleProps {
+interface Props {
   messageList: MessageList;
+  config?: Config;
 }
 
-const StyledApp = styled.main<StyleProps>`
+const StyledApp = styled.main<Config>`
   width: ${props  => `${props.width ?? '400'}px` };
   height: ${props => `${props.height ?? '600'}px` };
   display: flex;
@@ -21,8 +18,13 @@ const StyledApp = styled.main<StyleProps>`
 
 export const App = (props: Props) => {
   return (
-    <StyledApp width={props.width} height={props.height}>
+    <configContext.Provider value={props.config ?? null}>
+      <StyledApp width={props.config?.width} height={props.config?.height}>
         <ChatContainer messageList={props.messageList} />
-    </StyledApp>
+        {props.config?.inputBox && 
+          <InputBox />
+        }
+      </StyledApp>
+    </configContext.Provider>
   );
 };

--- a/src/components/ChatContainer/Balloon/Balloon.tsx
+++ b/src/components/ChatContainer/Balloon/Balloon.tsx
@@ -1,8 +1,9 @@
 import React, { forwardRef, ReactEventHandler, useMemo } from 'react';
 import styled, { css } from 'styled-components';
-import { Message, MessageWithImage, MessageWithText } from 'shared/models';
+import { Message, MessageWithButton, MessageWithImage, MessageWithText } from 'shared/models';
 import { Image } from './Image';
 import { Text } from './Text/Text';
+import { Button } from './Button/Button';
 
 interface StyleProps {
   type: Message['type'];
@@ -11,13 +12,27 @@ interface StyleProps {
 interface Props extends StyleProps {
   text?: MessageWithText['text'];
   image?: MessageWithImage['image'];
+  button?: MessageWithButton['button'];
   onLoadHandler: ReactEventHandler<HTMLElement>;
 }
 
-const StyledContent = styled.div`
+const content = css`
   border: 1px solid transparent;
   border-radius: 0.5em;
   padding: 0.4em 0.5em;
+
+  max-width: 70%;
+  width: max-content;
+  word-break: break-all;
+`;
+
+const StyledContent = styled.div`
+  text-align: left;
+  ${content}
+`;
+
+const StyledButtons = styled.div`
+  ${content}
 `;
 
 const StyledBalloonContainer = styled.article<StyleProps>`
@@ -30,6 +45,9 @@ const StyledBalloonContainer = styled.article<StyleProps>`
       & ${StyledContent} {
         background-color: #567ace; // TODO: 변수 입력
       }
+      & ${StyledButtons} button {
+        background-color: #567ace;
+      }
     `
   }
   // 오른쪽 말풍선
@@ -40,26 +58,28 @@ const StyledBalloonContainer = styled.article<StyleProps>`
       & ${StyledContent} {
         background-color: #db706c; // TODO: 변수 입력
       }
+      & ${StyledButtons} button {
+        background-color: #db706c;
+      }
     `
-  }
-
-  & ${StyledContent} {
-    max-width: 70%;
-    width: max-content;
-    text-align: left;
-    word-break: break-all;
   }
 `;
 
 export const Balloon = forwardRef<HTMLDivElement, Props>((props, ref) => {
   return useMemo(() => 
     <StyledBalloonContainer type={props.type} ref={ref} onLoad={props.onLoadHandler}>
-      <StyledContent>
-        { props.image && <Image src={props.image} /> }
-        { props.text && <Text text={props.text} /> }
-      </StyledContent>
+      { (props.image || props.text) &&
+        <StyledContent>
+          { props.image && <Image src={props.image} /> }
+          { props.text && <Text text={props.text} /> }
+        </StyledContent>
+      }
+      { props.button &&
+        <StyledButtons>
+        { props.button && <Button button={props.button} /> }
+        </StyledButtons>
+      }
     </StyledBalloonContainer>
-  , [props.text, props.type, props.image, props.onLoadHandler, ref]);
+  , [props.text, props.type, props.image, props.button, props.onLoadHandler, ref]);
   // ?: 로직상으로는 빈 배열 넣어도 됨, 다만 warning 발생함
 });
-

--- a/src/components/ChatContainer/Balloon/Button/Button.tsx
+++ b/src/components/ChatContainer/Balloon/Button/Button.tsx
@@ -1,0 +1,44 @@
+import React, { useContext } from 'react';
+import styled from 'styled-components';
+import { MessageWithButton } from 'shared/models';
+import { configContext } from 'context';
+
+interface Props {
+  button: MessageWithButton['button'];
+}
+
+const StyledButton = styled.button`
+  color: #f2f2f2;
+  
+  padding: 0.5em;
+  border: none;
+  border-radius: 0.5em;
+  margin: 0.2em;
+
+  cursor: pointer;
+
+  &:active {
+    color: #666666;
+  }
+`;
+
+export const Button = (props: Props) => {
+  const config = useContext(configContext);
+
+  const onClick = (event: React.MouseEvent) => {
+    const $target = event.target as HTMLElement;
+    if (config?.sendCallback) {
+      config.sendCallback($target.dataset['value']);
+    }
+  };
+
+  return (
+    <>
+      {props.button.map(each => 
+        <StyledButton key={each.name} type="button" data-value={each.value} onClick={onClick}>
+          {each.name}
+        </StyledButton>
+      )}
+    </>
+  );
+};

--- a/src/components/ChatContainer/ChatContainer.tsx
+++ b/src/components/ChatContainer/ChatContainer.tsx
@@ -46,6 +46,7 @@ export const ChatContainer = (props: Props) => {
             type={each.type}
             text={each.text}
             image={each.image}
+            button={each.button}
             ref={lastBalloon}
             onLoadHandler={onLoadHandler}
           />

--- a/src/components/InputBox/InputBox.tsx
+++ b/src/components/InputBox/InputBox.tsx
@@ -1,0 +1,28 @@
+import React, { useContext, useState } from 'react';
+import styled from 'styled-components';
+import { configContext } from 'context';
+
+const StyledInput = styled.input`
+  padding: 0.5em;
+`;
+
+export const InputBox = () => {
+  const config = useContext(configContext);
+
+  const [value, setValue] = useState('');
+
+  const onKeyDown = (event: React.KeyboardEvent) => {
+    if (event.key === 'Enter') {
+      if (config?.sendCallback) {
+        config.sendCallback(value);
+      }
+      setValue('');
+    }
+  };
+
+  return (
+    <StyledInput value={value}
+      onKeyDown={onKeyDown}
+      onChange={event => setValue(event.target.value)} />
+  );
+};

--- a/src/components/index.ts
+++ b/src/components/index.ts
@@ -1,2 +1,3 @@
 export { ChatContainer } from './ChatContainer/ChatContainer';
 export { Balloon } from './ChatContainer/Balloon/Balloon';
+export { InputBox } from './InputBox/InputBox';

--- a/src/context/configContext.ts
+++ b/src/context/configContext.ts
@@ -1,0 +1,4 @@
+import React from 'react';
+import { Config } from 'shared/models';
+
+export const configContext = React.createContext<Config | null>(null);

--- a/src/context/index.ts
+++ b/src/context/index.ts
@@ -1,0 +1,1 @@
+export { configContext } from './configContext';

--- a/src/shared/models/Config.ts
+++ b/src/shared/models/Config.ts
@@ -1,0 +1,6 @@
+export interface Config {
+  width?: number;
+  height?: number;
+  sendCallback?: Function;
+  inputBox?: boolean;
+}

--- a/src/shared/models/MessageModel.ts
+++ b/src/shared/models/MessageModel.ts
@@ -6,13 +6,26 @@ export interface MessageBasics {
 export interface MessageWithText extends MessageBasics {
   text: string;
   image?: never;
+  button?: never;
 }
 
 export interface MessageWithImage extends MessageBasics {
   image: string;
   text?: never;
+  button?: never;
 }
 
-export type Message = MessageWithImage | MessageWithText;
+export interface MessageButton {
+  name: string;
+  value: any;
+}
 
-export type MessageList = Array<MessageWithImage | MessageWithText>;
+export interface MessageWithButton extends MessageBasics {
+  button: Array<MessageButton>;
+  text?: never;
+  image?: never;
+}
+
+export type Message = MessageWithImage | MessageWithText | MessageWithButton;
+
+export type MessageList = Array<Message>;

--- a/src/shared/models/index.ts
+++ b/src/shared/models/index.ts
@@ -2,5 +2,10 @@ export type {
   Message,
   MessageWithImage,
   MessageWithText,
+  MessageWithButton,
   MessageList
 } from './MessageModel';
+
+export type { 
+  Config
+} from './Config';


### PR DESCRIPTION
- Config Context
  - ChatBotUI 의 props로 입력되는 config 객체의 인터페이스 생성함
  - 해당 객체는 Context를 통해 컴포넌트 전체에 주입되어 이곳저곳 사용됨
    - Container의 width, height값 입력
    - Button과 InputBox로 전달받을 입력값을 인자로 받는 sendCallback 함수 정의
    - InputBox를 사용할 지, 말지 입력

- Button Component
  - Text, Image와 같이 있을 수 없는 Button 컴포넌트 생성함
  - 버튼을 클릭하면, 버튼의 dataset['value'] 값을 인자로 config.sendCallback 함수가 실행됨

- InputBox Component
  - config.InputBox를 true로 하면 사용할 수 있음 (default: false)
  - InputBox에 값을 입력하고 엔터 키를 누르면, 입력값을 인자로 config.sendCallback 함수가 실행됨

close #14